### PR TITLE
add SessionStart hook for morning brief

### DIFF
--- a/dot_claude/hooks/morning-brief.sh
+++ b/dot_claude/hooks/morning-brief.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# SessionStart hook: brief project context for new sessions.
+# stdout is injected into Claude's first-turn context and shown in the transcript.
+
+set -euo pipefail
+
+git rev-parse --git-dir > /dev/null 2>&1 || exit 0
+
+printf "## session start context\n"
+printf "branch: %s\n" "$(git rev-parse --abbrev-ref HEAD)"
+
+modified=$(git status -s --untracked-files=no | wc -l | tr -d ' ')
+if [ "$modified" -gt 0 ]; then
+    printf "uncommitted (tracked): %s files\n" "$modified"
+    git status -s --untracked-files=no | head -5 | sed 's/^/  - /'
+fi
+
+if command -v gh > /dev/null 2>&1; then
+    prs=$(gh pr list --assignee @me --limit 5 --json number,title 2>/dev/null || true)
+    if [ -n "$prs" ] && [ "$prs" != "[]" ]; then
+        printf "\nmy open prs:\n"
+        echo "$prs" | jq -r '.[] | "  - #\(.number) \(.title)"'
+    fi
+fi

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -316,6 +316,18 @@
     "defaultMode": "bypassPermissions"
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.claude/hooks/morning-brief.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary
- git リポジトリ内で新規セッション開始時に、簡潔な context を Claude に注入する hook
- 出力は Claude の first-turn context にも transcript にも入る
- 同期実行（SessionStart は async 非対応）。重いコマンドは避けている

## 中身
- `dot_claude/hooks/morning-brief.sh` 新規（実行権限付）
- \`settings.json\` の \`hooks\` に \`SessionStart\` を追加
- \`matcher: \"startup\"\` で resume/clear/compact 時は実行しない
- timeout: 10 秒

## 出力例
\`\`\`
## session start context
branch: feat/auth-refactor
uncommitted (tracked): 3 files
  - M  src/auth.ts
  - M  src/login.tsx
  - A  src/oauth.ts

my open prs:
  - #5 split CLAUDE.md into topic-based rules/
  - #6 add custom output styles
\`\`\`

## graceful 動作
- git 外: 何も出力せず exit 0
- gh 未インストール: PR セクションをスキップ
- PR 無し: PR セクションをスキップ

## 仕様根拠
[Hooks - Claude Code Docs](https://code.claude.com/docs/en/hooks):
- SessionStart の \`source\` matcher（startup/resume/clear/compact）
- stdout が \`additionalContext\` として Claude に渡る
- SessionStart は \`async\` 非対応

## Test plan
- [ ] git リポジトリで \`claude\` 起動 → brief が表示される
- [ ] git 外で起動 → 何も表示されない
- [ ] \`/clear\` で hook が走らない（matcher: startup フィルタ）
- [ ] \`claude -r <session>\` で hook が走らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)