### PR TITLE
add PreCompact snapshot hook

### DIFF
--- a/dot_claude/hooks/pre-compact-save.sh
+++ b/dot_claude/hooks/pre-compact-save.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# PreCompact hook: snapshot session state into the workspace memory/ before compaction.
+# Workspace dir convention: /Users/.../.claude/projects/<cwd-with-slashes-and-dots-replaced-by-dashes>/memory/
+
+set -euo pipefail
+
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.cwd // empty')
+transcript_path=$(echo "$input" | jq -r '.transcript_path // empty')
+
+[ -z "$cwd" ] && exit 0
+
+workspace=$(echo "$cwd" | tr '/.' '-')
+memory_dir="$HOME/.claude/projects/$workspace/memory"
+mkdir -p "$memory_dir"
+
+timestamp=$(date +%Y-%m-%dT%H-%M-%S)
+out="$memory_dir/compact-$timestamp.md"
+
+branch=""
+if (cd "$cwd" && git rev-parse --git-dir > /dev/null 2>&1); then
+    branch=$(cd "$cwd" && git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+fi
+
+cat > "$out" <<EOF
+---
+name: compact-$timestamp
+description: PreCompact 時のスナップショット ($branch)
+metadata:
+  type: snapshot
+  cwd: $cwd
+  branch: $branch
+  at: $(date -Iseconds)
+---
+
+# Pre-Compact Snapshot
+
+このセッションは context compaction を経た。圧縮前の状態:
+
+- cwd: $cwd
+- branch: $branch
+- timestamp: $(date -Iseconds)
+EOF
+
+if [ -n "$transcript_path" ] && [ -f "$transcript_path" ]; then
+    prompts=$(jq -r '
+        select(.type == "user" and (.message.content | type) == "string")
+        | .message.content
+    ' "$transcript_path" 2>/dev/null | grep -v '^$' | tail -5 || true)
+    if [ -n "$prompts" ]; then
+        {
+            echo ""
+            echo "## 圧縮前の直近 user prompt (最大 5 件)"
+            echo ""
+            echo "$prompts" | sed 's/^/- /'
+        } >> "$out"
+    fi
+fi
+
+exit 0

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -354,6 +354,17 @@
           }
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.claude/hooks/pre-compact-save.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## Summary
- context compaction の直前に workspace memory ディレクトリへスナップショットを書き出す hook
- 圧縮で失われがちな「直前の話題」を後から辿れるようにする

## 中身
- \`dot_claude/hooks/pre-compact-save.sh\` 新規（実行権限付）
- \`settings.json\` に \`PreCompact\` フック追加（timeout 10s）

## 保存先・形式
- パス: \`~/.claude/projects/<workspace>/memory/compact-<timestamp>.md\`
- workspace 名: cwd を \`tr '/.' '-'\` で変換した文字列
  - 例: \`/Users/x/y\` → \`-Users-x-y\`
- ファイル形式: 自動メモリと同じ frontmatter + 本文 markdown

## 保存内容
- cwd / branch / ISO8601 タイムスタンプ
- transcript_path から取り出した直近の user prompt（string content のみ、最大 5 件、ベストエフォート）

## graceful 動作
- cwd 無し: 何もせず exit 0
- transcript_path 読めない / jq parse 失敗: prompt セクションを省略してメタ情報のみ保存

## 仕様根拠
- 自動メモリの規約: 親 system prompt の \`# auto memory\` セクション
- PreCompact event: [Hooks - Claude Code Docs](https://code.claude.com/docs/en/hooks)

## Test plan
- [ ] 長い会話で \`/compact\` を実行 → memory/ にファイルが追加される
- [ ] 別プロジェクトに \`cd\` して \`/compact\` → 別の workspace dir に保存される
- [ ] memory ファイルを後の Claude セッションが参照できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)