### PR TITLE
add Context7 MCP server

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -378,6 +378,12 @@
       }
     }
   },
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  },
   "outputStyle": "Explanatory",
   "spinnerVerbs": {
     "mode": "replace",


### PR DESCRIPTION
## Summary
- 最新ライブラリ docs を Claude に渡す MCP server を \`mcpServers\` 設定に追加
- LLM の学習データが古いことに起因する hallucination を削減

## 中身
\`settings.json\` の \`mcpServers\` に context7 を追加（npx で起動、API key なし設定）

## 動作確認
- セッション起動後 \`/mcp\` で context7 が connected 表示されること
- 「Next.js 16 の app router で X するには？」のような質問で最新仕様が返ること

## 仕様根拠
- 公式: [Context7 MCP installation](https://context7mcp.com/install/)
- 解説: [claudefa.st - Context7 MCP](https://claudefa.st/blog/tools/mcp-extensions/context7-mcp)

## オプション
API key を設定するとレートリミット緩和（無料登録）。必要なら settings.json の args に \`--api-key\` を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)