### PR TITLE
add cc-caffeine plugin (keep Mac awake during agent work)

### DIFF
--- a/dot_claude/marketplace-plugins.txt
+++ b/dot_claude/marketplace-plugins.txt
@@ -5,3 +5,4 @@ ww@cc-plugins
 rust-analyzer-lsp@claude-plugins-official
 code-simplifier@claude-plugins-official
 gopls-lsp@claude-plugins-official
+cc-caffeine@samber

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -368,13 +368,20 @@
     "code-simplifier@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "swift-lsp@claude-plugins-official": true,
-    "ui-ux-pro-max@ui-ux-pro-max-skill": true
+    "ui-ux-pro-max@ui-ux-pro-max-skill": true,
+    "cc-caffeine@samber": true
   },
   "extraKnownMarketplaces": {
     "ui-ux-pro-max-skill": {
       "source": {
         "source": "github",
         "repo": "nextlevelbuilder/ui-ux-pro-max-skill"
+      }
+    },
+    "samber": {
+      "source": {
+        "source": "github",
+        "repo": "samber/cc"
       }
     }
   },


### PR DESCRIPTION
## Summary
- dev-loop 等の長時間タスク中に Mac が sleep に落ちないようにする plugin を導入
- 蓋を閉じても agent が動き続ける

## 中身
- \`marketplace-plugins.txt\` に \`cc-caffeine@samber\` を追加
- \`settings.json\`:
  - \`extraKnownMarketplaces.samber\` を登録（samber/cc リポジトリ）
  - \`enabledPlugins\` に \`cc-caffeine@samber: true\` を追加

## 動作
plugin として import すると以下が自動で hook 化される:
- UserPromptSubmit / PreToolUse / PostToolUse → caffeinate
- Notification / Stop / SessionEnd → uncaffeinate

つまり「agent が作業中だけ Mac が起きてる」状態になる。

## 仕様根拠
- 公式: [samber/cc-caffeine](https://github.com/samber/cc-caffeine)
- crossplatform (macOS / Linux / Windows)

## Test plan
- [ ] 新セッションで plugin がロードされること（\`/plugin list\` で確認）
- [ ] 長時間の dev-loop 中、システム設定の sleep 時間が来ても起きていること
- [ ] Stop / SessionEnd 後は通常の sleep に戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)