### PR TITLE
add TTS Stop hook (macOS say, Japanese, background)

### DIFF
--- a/dot_claude/hooks/tts-notify.sh
+++ b/dot_claude/hooks/tts-notify.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Stop hook: announce task completion via macOS say (background, non-blocking).
+# macOS only; no-op on other platforms.
+
+set -euo pipefail
+
+[[ "$(uname)" != "Darwin" ]] && exit 0
+command -v say > /dev/null 2>&1 || exit 0
+
+messages=(
+    "完了です"
+    "終わったよ"
+    "お疲れさま"
+    "できました"
+    "本当に偉い"
+    "ごきげんよう"
+    "パン"
+    "良い夢を"
+)
+msg="${messages[$RANDOM % ${#messages[@]}]}"
+
+say -v Kyoko "$msg" > /dev/null 2>&1 &
+disown
+
+exit 0

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -332,6 +332,14 @@
             "command": "\"$HOME/.claude/hooks/focus-wezterm.sh\""
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.claude/hooks/tts-notify.sh\""
+          }
+        ]
       }
     ],
     "Notification": [


### PR DESCRIPTION
## Summary
- Stop イベント時に macOS の \`say\` コマンドで日本語音声で完了を知らせる hook
- 既存の \`focus-wezterm.sh\` や \`check-tentative-language.py\` と並ぶ 3 つ目の Stop hook
- バックグラウンド実行で hook は即返却（Claude のターン終了を遅らせない）

## 中身
- \`dot_claude/hooks/tts-notify.sh\` 新規（実行権限付き）
- \`settings.json\` の \`hooks.Stop\` に追加

## メッセージ集
spinnerVerbs のノリに合わせた 8 件からランダム 1 件:
完了です / 終わったよ / お疲れさま / できました / 本当に偉い / ごきげんよう / パン / 良い夢を

声: Kyoko (ja_JP)

## graceful 動作
- macOS 以外: 即 exit 0
- \`say\` コマンド不在: 即 exit 0
- 発話自体は \`& disown\` でバックグラウンド化、hook 完了を遅らせない

## Test plan
- [ ] 新セッションで claude 起動し、応答終了時に音声が鳴る
- [ ] ターン終了が遅延しない（hook が即返却される）
- [ ] 連続応答時に音声が重ならず最新のもののみ聞こえる（要検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)