### PR TITLE
add three Anthropic official plugins

### DIFF
--- a/dot_claude/marketplace-plugins.txt
+++ b/dot_claude/marketplace-plugins.txt
@@ -5,3 +5,6 @@ ww@cc-plugins
 rust-analyzer-lsp@claude-plugins-official
 code-simplifier@claude-plugins-official
 gopls-lsp@claude-plugins-official
+commit-commands@claude-plugins-official
+security-guidance@claude-plugins-official
+feature-dev@claude-plugins-official

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -368,7 +368,10 @@
     "code-simplifier@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "swift-lsp@claude-plugins-official": true,
-    "ui-ux-pro-max@ui-ux-pro-max-skill": true
+    "ui-ux-pro-max@ui-ux-pro-max-skill": true,
+    "commit-commands@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "ui-ux-pro-max-skill": {


### PR DESCRIPTION
## Summary
Anthropic 公式 marketplace の中から、現状の setup で未導入かつ価値が明らかな 3 つを追加。

## 追加 plugin
| 名前 | 種別 | 効果 |
|---|---|---|
| \`commit-commands\` | slash commands | \`/commit-commands:commit\` で staging → メッセージ自動生成 → commit |
| \`security-guidance\` | PreToolUse hook | Edit/Write 時に command injection / XSS / unsafe code パターンを警告。\`dangerouslySetInnerHTML\` / \`document.write\` / Node \`exec\` などを検出 |
| \`feature-dev\` | 7 フェーズ workflow | Discovery → Exploration → Clarification → ... の機能開発オーケストレーション |

## 既存 setup との関係（要確認）
- **feature-dev**: あなたの \`dev-loop\` (dev-plan → dev-generate → dev-evaluate → dev-external-review) と用途が重なる。両方併存させる場合は使い分け基準が必要。一旦入れて比較してみてから片方を無効化する想定
- **security-guidance**: 既存の \`rtk-rewrite.sh\` (Bash PreToolUse) と並列で動く。security-guidance は Edit/Write が対象なので衝突なし
- **commit-commands**: 既存の自作 \`pr\` skill と並ぶ。commit-commands は commit 単位、pr skill は PR 単位、棲み分け可能

## 中身
- \`marketplace-plugins.txt\` に 3 行追加
- \`settings.json.enabledPlugins\` に 3 エントリ追加

## 仕様根拠
- [Anthropic claude-plugins-official](https://github.com/anthropics/claude-plugins-official)
- [Official marketplace guide](https://www.petegypps.uk/blog/claude-code-official-plugin-marketplace-complete-guide-36-plugins-december-2025)

## Test plan
- [ ] \`/plugin list\` で 3 つが enabled で出る
- [ ] \`/commit-commands:commit\` がコマンド一覧に出る
- [ ] Edit で危険パターン書いたら security-guidance が警告
- [ ] dev-loop と feature-dev を比較し、片方を無効化する判断（merge 後別 PR で）

🤖 Generated with [Claude Code](https://claude.com/claude-code)