### PR TITLE
add Karpathy-inspired guidelines plugin (disabled by default)

### DIFF
--- a/dot_claude/marketplace-plugins.txt
+++ b/dot_claude/marketplace-plugins.txt
@@ -5,3 +5,4 @@ ww@cc-plugins
 rust-analyzer-lsp@claude-plugins-official
 code-simplifier@claude-plugins-official
 gopls-lsp@claude-plugins-official
+andrej-karpathy-skills@karpathy-skills

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -368,13 +368,20 @@
     "code-simplifier@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "swift-lsp@claude-plugins-official": true,
-    "ui-ux-pro-max@ui-ux-pro-max-skill": true
+    "ui-ux-pro-max@ui-ux-pro-max-skill": true,
+    "andrej-karpathy-skills@karpathy-skills": false
   },
   "extraKnownMarketplaces": {
     "ui-ux-pro-max-skill": {
       "source": {
         "source": "github",
         "repo": "nextlevelbuilder/ui-ux-pro-max-skill"
+      }
+    },
+    "karpathy-skills": {
+      "source": {
+        "source": "github",
+        "repo": "forrestchang/andrej-karpathy-skills"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Karpathy の LLM coding 観察を構造化した plugin を install
- **デフォルトは disabled**。既存ルールと一部衝突するため、比較したうえで有効化したい場合は \`enabledPlugins\` で \`true\` に変更

## 中身
- \`marketplace-plugins.txt\` に \`andrej-karpathy-skills@karpathy-skills\` を追加
- \`settings.json\`:
  - \`extraKnownMarketplaces.karpathy-skills\` を登録（github: forrestchang/andrej-karpathy-skills）
  - \`enabledPlugins[\"andrej-karpathy-skills@karpathy-skills\"] = false\`

## 4 原則の概要
1. **Think Before Coding** — 仮定を明示する、不明点は質問
2. **Simplicity First** — 最小限のコード、speculative なし
3. **Surgical Changes** — 隣接コードを改良しない
4. **Goal-Driven Execution** — 検証可能な成功条件

## 既存ルールとの照合
| Karpathy | 既存 \`CLAUDE.md\` | 状態 |
|---|---|---|
| Think Before Coding | 推測するな、コードで検証せよ | 重複 |
| Simplicity First | YAGNI | 重複 |
| Surgical Changes | スコープクリープを避ける | 重複 |
| Don't 'improve' adjacent code | **Boy Scout Rule（触ったファイル内の小さな問題は今修正する）** | **衝突** |
| Goal-Driven Execution | （明示なし） | 補完 |

## 有効化する場合
\`\`\`diff
- "andrej-karpathy-skills@karpathy-skills": false
+ "andrej-karpathy-skills@karpathy-skills": true
\`\`\`

ただし上記の Boy Scout 衝突をどう扱うか先に決める必要あり。

## 仕様根拠
- 元ネタ: [Andrej Karpathy on X (2026-01-26)](https://x.com/karpathy)
- 配布: [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills)
- 解説: [pasqualepillitteri.it - Karpathy CLAUDE.md](https://pasqualepillitteri.it/en/news/1872/karpathy-claude-md-trending-github-llm-coding)

## Test plan
- [ ] \`/plugin list\` で installed だが disabled として表示される
- [ ] \`true\` に切り替えて 1-2 セッション試し、Boy Scout 衝突の影響を観察
- [ ] 衝突が許容できないなら \`false\` に戻すか、既存 Boy Scout Rule を緩める判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)