### PR TITLE
Add PreToolUse hook to block autonomous PR merges

### DIFF
--- a/dot_claude/hooks/block-pr-merge.sh
+++ b/dot_claude/hooks/block-pr-merge.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PreToolUse guard: PR マージ操作は必ずユーザーの明示承認を挟む。
+# Bash の `gh pr merge` 系コマンド、および mcp__github__merge_pull_request の呼び出しを
+# 検知したら permissionDecision "ask" を返し、人間の確認を強制する。
+# defaultMode: auto でも例外を作らない(自律マージ禁止の原則をツール層で担保する)。
+# jq が無い / 入力が壊れている等で判定不能なときだけ exit 0 (fail open) で通常フローに委ねる。
+set -u
+
+input="$(cat)"
+
+# jq が無ければ判定不能 → fail open
+command -v jq >/dev/null 2>&1 || exit 0
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null)"
+[ -z "$tool_name" ] && exit 0
+
+reason="PR マージはユーザーの明示承認が必要。マージ可能と報告して指示を待つこと。"
+
+ask() {
+  jq -n --arg r "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+}
+
+case "$tool_name" in
+  mcp__github__merge_pull_request)
+    ask
+    ;;
+  Bash)
+    cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+    # `gh pr merge`(空白は可変、merge の後は空白か行末) を含むコマンドを検知
+    if printf '%s' "$cmd" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'; then
+      ask
+    fi
+    ;;
+esac
+
+exit 0

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -47,6 +47,26 @@
   },
   "feedbackSurveyRate": 0,
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "command": "$HOME/.claude/hooks/block-pr-merge.sh",
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__github__merge_pull_request",
+        "hooks": [
+          {
+            "command": "$HOME/.claude/hooks/block-pr-merge.sh",
+            "type": "command"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "hooks": [


### PR DESCRIPTION
## 概要

PR マージを自律実行させないための PreToolUse hook `dot_claude/hooks/block-pr-merge.sh` を新設し、`dot_claude/settings.json` に配線する。CI green でもマージは常にユーザーの明示承認を挟むという原則を、散文（CLAUDE.md）だけでなくツール層でも強制する。

## 変更内容

- `dot_claude/hooks/block-pr-merge.sh`（新規、`chmod +x` 済み / 100755）
  - stdin の JSON から `tool_name` を読む。
  - `mcp__github__merge_pull_request` はそのまま `ask`。
  - `Bash` は `tool_input.command` を見て `gh pr merge`（空白可変・`merge` の後は空白/行末）にマッチしたときだけ `ask`。
  - `permissionDecision: "ask"` を `hookSpecificOutput` で返す（理由: 「PR マージはユーザーの明示承認が必要。マージ可能と報告して指示を待つこと。」）。
  - `jq` 不在・JSON 破損など判定不能時は `exit 0`（fail open）。既存 `detect-toolcall-leak.sh` の書式・エラーハンドリングに合わせた。
- `dot_claude/settings.json` の `hooks.PreToolUse` に matcher `Bash` と `mcp__github__merge_pull_request` の 2 エントリを追加。既存 hook 群（Notification/Stop/SubagentStop）はそのまま。

## 動作確認

サンプル JSON を stdin に食わせて確認（全 7 ケース期待通り、`jq` で settings.json も妥当性検証済み）。

- `Bash` + `gh pr merge 12 --squash` → `ask` を出力
- `Bash` + `gh pr create -t x` → 出力なし（通常フロー）
- `mcp__github__merge_pull_request` → `ask` を出力
- `Bash` + `ls -la` → 出力なし
- `Bash` + `gh pr view --json mergeable`（false-positive ガード）→ 出力なし
- `Bash` + `gh  pr   merge`（空白可変）→ `ask` を出力
- 非 JSON 入力（判定不能）→ 出力なし・exit 0（fail open）

いずれも exit code 0。出力仕様は公式ドキュメント（https://code.claude.com/docs/en/hooks）の PreToolUse permissionDecision に準拠。

## 根拠

監査で、リリース PR を自律マージし revert に至った重大事故が観測された（「何でもかんでも自動マージしていいわけなくない？」という強い叱責を含む）。CLAUDE.md/AGENTS.md の散文ガードはドリフトするため、ツール層で人間確認を必ず挟む。「自律マージ禁止」は特定リポの例外にせず user スコープ hook として全リポに効かせる。

## 反映について

`~/.claude/settings.json` は symlink ではなくコピー同期のため、マージ後に `./setup-claude.sh`（または `make claude-apply` 相当）の再実行が必要。hook 本体（`dot_claude/hooks/`）は symlink 配下なので追加操作は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)