### PR TITLE
Add rules for CLAUDE.md authoring and skill placement

### DIFF
--- a/dot_claude/rules/claude-md-authoring.md
+++ b/dot_claude/rules/claude-md-authoring.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "**/CLAUDE.md"
+  - "**/AGENTS.md"
+---
+
+# CLAUDE.md / AGENTS.md 編集ガイド
+
+`CLAUDE.md` / `AGENTS.md` を編集・新規作成するときに従う。
+
+- **開発に必要な非自明情報だけを書く。** そのリポで作業する人（や Claude）が
+  コードを読んでも分からない前提・規約・ハマりどころを書く。
+- **コード・`package.json` から分かることは書かない。** スクリプト名・ディレクトリ構成・
+  自明なコマンドは書かない（コードが正。ドキュメントに複製すると変更に追従できずドリフトする）。
+- **目安 70 行以下。** 長くなるなら、静的に効かせたいルールは `paths` 付きの
+  path-specific rule（`.claude/rules/`）へ、手順は skill へ分割する。
+- **変更前に公式ドキュメントを確認する**: memory / CLAUDE.md の仕様を最新で確認してから着手する。
+  - https://code.claude.com/docs/en/memory

--- a/dot_claude/rules/skill-placement.md
+++ b/dot_claude/rules/skill-placement.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "**/.claude/skills/**"
+  - "**/dot_claude/skills/**"
+  - "**/.claude/commands/**"
+  - "**/dot_claude/commands/**"
+---
+
+# skill / command の置き場所・命名ガイド
+
+skill / command を新規作成するときに、置き場所とスコープを次の決定木で決める。
+「どこに入れるか」を毎回迷わないための基準。
+
+## 置き場所（上から順に判定）
+
+1. **秘密情報（メールアドレス / PII / 金額 / トークン等）を含むか**
+   → private リポ（例: `private-files` / `tasks`）の `.claude/` に置く。
+   **公開リポ（dotfiles）には置かない。** アドレス等は直書きせず、実行時に認証情報から導出する。
+2. **複数リポ横断で使うか**
+   → user スコープ（`dot_claude/skills/`。`setup-claude.sh` で `~/.claude/skills/` へ symlink される）。
+3. **特定リポに閉じるか**
+   → そのリポの `.claude/skills/`（または `.claude/commands/`）。
+
+## 命名
+
+- **kebab-case**、**動詞-目的語**、**後で思い出せる**名前にする。
+  （`overdue-tasks` のような目的語先行の名前は、いざ叩くとき思い出せなかった実例がある。
+  `next-todo` のように「何をするか」で引ける名前にする。）
+
+## 補足
+
+- 試作は `~/.claude/skills/` で作って試し、良ければ `dot_claude/skills/` へ昇格する
+  （詳細は `dot_claude/README.md`）。


### PR DESCRIPTION
## 概要

CLAUDE.md 執筆と skill/command 配置の判断基準を path-specific rule として追加する（`dot_claude/rules/`）。既存 `authoring-rules.md` の作法（`paths` frontmatter）に従う。

## 変更内容

- `claude-md-authoring.md`（paths: `**/CLAUDE.md`, `**/AGENTS.md`）: 非自明情報のみを書く / `package.json`・コードから分かることは書かない（ドリフト防止）/ 目安 70 行以下 / 長くなるなら rule・skill に分割 / 変更前に memory 公式ドキュメント確認。
- `skill-placement.md`（paths: `**/.claude/skills/**`, `**/dot_claude/skills/**`, `**/.claude/commands/**`, `**/dot_claude/commands/**`）: 置き場所の決定木（秘密情報→private リポ / 横断→user `dot_claude/skills/` / リポ固有→repo `.claude/skills/`）と命名（kebab-case・動詞-目的語・後で思い出せる名前）。

## 根拠

監査で、CLAUDE.md を「70 行以下で十分」「コードを見たら分かるものは書かない」と明示指示した例が複数回、skill/command の置き場所（公開/非公開リポ・user/repo スコープ）を毎回迷い、命名を思い出せなかった例が最頻出のメタパターンとして観測された。静的に効かせられる作法を rule 層に落とす。

## 反映について

`dot_claude/rules/` は `~/.claude/rules/` へ symlink されるため、マージ後の追加操作は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)