### PR TITLE
Log next-todo-mail send result, add mobile-traffic-analysis skill, gitignore flows

### DIFF
--- a/.claude/commands/next-todo-mail.md
+++ b/.claude/commands/next-todo-mail.md
@@ -8,12 +8,25 @@ GitHub Project の期日超過タスクを取得し、アクション化した�
 2. `[Done]` を除外する（完了済みは対応不要）。Done 以外が 0 件なら、本文を「対応が必要なタスクはありません」としてそのまま送信に進む。
 3. Done 以外の各タスクについて、issue 本文・コメントを読んで判断材料を補い、「次に取るべき具体的な一手」に変換する。優先度は経過日数の長さではなく不可逆リスクの大きさで並べる（自動課金・解約期限 > 申込・エントリー締切 > 外部締切のない調査）。private リンク（アクセス不可なもの）は推測で埋めず「リンク先を要確認」と残す。
 4. プレーンテキストのダイジェストを `/tmp/next-todo-digest.txt` に書き出す。各タスクに `期日 / 経過日数 / Status / タスク / 次の一手 / Issue URL` を含める。
-5. 送信先を認証情報から実行時に導出し、Gmail に送信する（アドレスをこのファイルに書かない）。
+5. 送信先を認証情報から実行時に導出し、Gmail に送信する（アドレスをこのファイルに書かない）。送信結果は次のステップで必ずログに残すので、`rm` の前に出力と終了コードを捕捉する。
    ```bash
    to=$(gog auth list -j | jq -r '.accounts[0].email')
-   gog send --to "$to" --subject "next-todo digest $(date +%F)" --body-file /tmp/next-todo-digest.txt --no-input
+   send_out=$(gog send --to "$to" --subject "next-todo digest $(date +%F)" --body-file /tmp/next-todo-digest.txt --no-input 2>&1)
+   send_rc=$?
    rm -f /tmp/next-todo-digest.txt
    ```
-6. 返ってきた `message_id` を確認し、送信成功を報告する。送信が失敗した場合（`invalid_grant` 等）は握りつぶさず、`gog auth doctor` の結果とともに原因を報告する。トークン失効なら `gog auth add <account>` での再認証が必要なことを伝える。
+6. **送信結果（成功/失敗 + 件数）をログと標準出力の両方に残す。** `/loop` の無人実行では会話上の報告が読まれず「届いてない」で気づく事故が起きるため、可視性を必ずファイルに落とす。`count` は step 2〜3 の Done 以外の件数（0 件ならその旨）。
+   ```bash
+   count=<Done 以外の件数>
+   log="$HOME/.claude/logs/next-todo-mail.log"
+   mkdir -p "$(dirname "$log")"
+   if [ "$send_rc" -eq 0 ]; then
+     mid=$(printf '%s' "$send_out" | jq -r '.message_id // empty' 2>/dev/null)
+     printf '%s\tSUCCESS\tcount=%s\tmessage_id=%s\n' "$(date +%FT%T%z)" "$count" "${mid:-?}"
+   else
+     printf '%s\tFAILURE\tcount=%s\terror=%s\n' "$(date +%FT%T%z)" "$count" "$(printf '%s' "$send_out" | head -1)"
+   fi | tee -a "$log"
+   ```
+7. ログ行の内容（成功/失敗・件数・message_id）を報告する。送信が失敗した場合（`invalid_grant` 等）は握りつぶさず、`gog auth doctor` の結果とともに原因を報告する。トークン失効なら `gog auth add <account>` での再認証が必要なことを伝える。
 
 追加指示: $ARGUMENTS

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ nix/local/identity.nix
 
 .DS_Store
 __pycache__/
+
+# mitmdump キャプチャ(大容量バイナリ)。手順は mobile-traffic-analysis skill 参照
+flows

--- a/dot_claude/skills/mobile-traffic-analysis/SKILL.md
+++ b/dot_claude/skills/mobile-traffic-analysis/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: mobile-traffic-analysis
+description: iOS/Android アプリの通信を mitmproxy で解析する手順。セットアップ・CA 証明書・cert pinning 判別・flows の読み方。トリガー - 通信解析, mitmproxy, mitmdump, パケットキャプチャ, アプリの通信を読む, cert pinning
+---
+
+# モバイルアプリ通信解析
+
+iOS/Android アプリの HTTPS 通信を mitmproxy で中継して読む定型手順。一般的な手順のみ。
+
+## 1. セットアップ
+
+```bash
+brew install mitmproxy
+```
+
+- `mitmproxy`: TUI で対話的に見る
+- `mitmweb`: ブラウザ UI で見る
+- `mitmdump`: 非対話。記録・スクリプト向き（`-w <file>` でキャプチャ保存）
+
+まず PC 側でプロキシを起動する（デフォルト `:8080`）。
+
+```bash
+mitmweb            # または mitmproxy
+mitmdump -w flows  # ファイルに記録する場合
+```
+
+## 2. 端末をプロキシ経由にする
+
+- 端末を PC と同じ Wi-Fi に接続。
+- 端末の Wi-Fi 詳細でプロキシを手動設定し、host に PC の LAN IP、port に `8080` を指定。
+
+## 3. CA 証明書のインストールと信頼
+
+mitmproxy の CA を端末に入れて信頼させないと HTTPS は復号できない。
+
+- 端末ブラウザで `http://mit.it/`（プロキシ経由時に配布される）から証明書を取得。
+- **iOS**: プロファイルをインストール後、`設定 > 一般 > VPN とデバイス管理` で承認し、
+  さらに `設定 > 一般 > 情報 > 証明書信頼設定` で当該 CA を有効化する（この最後の手順を忘れると信頼されない）。
+- **Android**: user 証明書としてインストール。ただし API 24+ ではアプリが
+  `networkSecurityConfig` で user CA を信頼しない限りアプリ通信は復号できない。
+  システム CA として入れるには root / Magisk が要る。
+
+## 4. cert pinning の判別と回避可否
+
+- 証明書を正しく入れてもハンドシェイクで切れる / 特定の通信だけ見えない場合は
+  **certificate pinning** の疑い。アプリが期待する証明書/公開鍵を固定しており、
+  MITM 証明書を拒否している。
+- pinning は中間者攻撃（通信の盗聴・改ざん）を防ぐための仕組み。解析側から見ると壁になる。
+- 回避可否はアプリ依存:
+  - Android: apk を展開して `networkSecurityConfig` を書き換え再署名、または Frida/objection で
+    pinning バイパス（要環境構築）。
+  - iOS 実機: 難度が高い。jailbreak + Frija/objection 前提になりやすい。
+- 業務・自己所有アプリの検証など、正当な権限がある対象に限って行う。
+
+## 5. キャプチャと flows の読み方
+
+```bash
+mitmdump -w flows          # 記録
+mitmproxy -r flows         # TUI で読み返す
+mitmweb -r flows           # ブラウザで読み返す
+```
+
+- フィルタ例（mitmproxy 内 / `-r` 時）:
+  - `~u <regex>`: URL でフィルタ
+  - `~d <host>`: ドメインでフィルタ
+  - `~m POST`: メソッドでフィルタ
+  - `~t json`: content-type でフィルタ
+- 内部 API の把握には、対象操作を端末で 1 度行い、その前後の flow だけを絞って読むと速い。


### PR DESCRIPTION
## 概要

監査で挙がった dotfiles の小物 3 点をまとめて対応する。

## 変更内容

- `.claude/commands/next-todo-mail.md`: 送信後に **送信結果（成功/失敗 + 件数 + message_id）を耐久ログ（`~/.claude/logs/next-todo-mail.log`）と標準出力の両方に残す**ステップを追加。`rm` の前に送信出力・終了コードを捕捉し、`tee -a` で記録する。無人 `/loop` 実行では会話上の報告が読まれず「届いてない」で気づく事故が起きていたため、可視性をファイルに落とす。
- `dot_claude/skills/mobile-traffic-analysis/SKILL.md`（新規）: mitmproxy/mitmdump のセットアップ、端末プロキシ設定、CA 証明書のインストールと信頼（iOS の証明書信頼設定・Android の networkSecurityConfig の注意）、cert pinning の判別と回避可否、`flows` の読み方（`mitmproxy -r flows` とフィルタ）。一般手順のみで機微情報は含まない。
- `.gitignore`: `flows`（4.6MB の mitmdump キャプチャ）を無視対象に追加。

## flows について（git rm ではなく gitignore にした理由）

`flows` は **origin/main でも履歴でも一度も追跡されていない**（`git ls-files flows` / `git cat-file -e origin/main:flows` とも空）。ローカル作業ツリーに未追跡ファイルとして存在するだけなので `git rm` は対象がなく実行できない。意図（リポ管理から外す・誤コミットを防ぐ）を満たすため `.gitignore` に追加した。ローカルの `flows` 実ファイルは削除していないので必要なら復元可能。

## 根拠

next-todo-mail の沈黙失敗は複数セッションで再発。通信解析は「手順をまとめたい」という明示依頼が未完のままキャプチャバイナリだけが残っていた。flows は公開リポに置くべきでない大容量バイナリ。

## 反映について

`.claude/commands/next-todo-mail.md` と `.gitignore` はこのリポジトリ固有（`~/.claude` へは同期されない）。`dot_claude/skills/mobile-traffic-analysis` は新規 custom skill のため、未 symlink 環境では `./setup-claude.sh` の再実行で `~/.claude/skills/` に反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)